### PR TITLE
Fix char_number reset variable

### DIFF
--- a/Morp/morp.py
+++ b/Morp/morp.py
@@ -62,7 +62,7 @@ class Morp:
                     else:
                         dict[char] = char_number
                     char_number += 1
-                cahr_number = 0  # reset
+                char_number = 0  # reset
 
             first_flag = 1
             for text_path in text_path_list:


### PR DESCRIPTION
## Summary
- fix typo when resetting the `char_number` counter in training

## Testing
- `python -m py_compile Morp/morp.py`